### PR TITLE
Broken Changelog syntax breaking GPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 
 1. [](#improved)
   * Fix formatting on changelog entries
-1. [](#improved)
   * Fix docs label in blueprint
 
 # v0.1.2
@@ -11,9 +10,7 @@
 
 1. [](#improved)
   * Updates to blueprints.yaml to improve listing
-1. [](#improved)
   * Updates to contact email and URL
-1. [](#improved)
   * Updates to Changelog.md to bring it inline with GRAV format.
 
 # v0.1.1


### PR DESCRIPTION
I've removed your plugin from GPM until you can re-release with this correct changelog format.